### PR TITLE
Fix: Use setting text property for plugin settings display name if available

### DIFF
--- a/src/managers/highlite/settingsManager.ts
+++ b/src/managers/highlite/settingsManager.ts
@@ -502,14 +502,12 @@ export class SettingsManager {
                 contentRow.style.boxShadow = '0 2px 4px rgba(0, 0, 0, 0.3)';
             });
 
-            // Capitalize the first letter of the name
+            // Use the setting's text property if available, otherwise generate from key name
             const capitalizedSettingName = settingKey.replace(
                 /([A-Z])/g,
                 ' $1'
             );
-            const finalizedSettingName =
-                capitalizedSettingName.charAt(0).toUpperCase() +
-                capitalizedSettingName.slice(1);
+            const finalizedSettingName = setting.text ? setting.text : capitalizedSettingName.charAt(0).toUpperCase() + capitalizedSettingName.slice(1);
 
             // Add appropriate input and label based on the setting name and type
 


### PR DESCRIPTION
Updated the logic for generating setting display names to use the 'text' property from the setting object when available, falling back to a capitalised key name otherwise. 

Assuming this is a fix otherwise the text field in settings are not used