### PR TITLE
fix: Metal Type includes silver

### DIFF
--- a/src/managers/highlite/itemTooltip.ts
+++ b/src/managers/highlite/itemTooltip.ts
@@ -258,6 +258,7 @@ export class ItemTooltip {
                     'Bronze',
                     'Iron',
                     'Steel',
+                    'Silver',
                     'Palladium',
                     'Gold',
                     'Coronium',


### PR DESCRIPTION
Same fix as here https://github.com/Highl1te/HighliteDesktop/commit/4ffced743d6c9591c1add42e8e8226de14f94e9f